### PR TITLE
Add border in calendar around days with notes

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -27,7 +27,6 @@ const monday_first = date_ele.getAttribute('iso8601') === 'true'
 const timeFmt:any = parseInt(date_ele.getAttribute('timeFmt'),10)
 const theme:any = date_ele.getAttribute('theme')
 const enableWeekNum = date_ele.getAttribute('weekNum') === 'true'
-const calendarHighlightColor = date_ele.getAttribute('calendarHighlightColor')
 const enableCalendarHighlight = date_ele.getAttribute('enableCalendarHighlight') === "true"
 
 const calendar = new VanillaCalendar('#datepicker', {
@@ -48,8 +47,7 @@ const calendar = new VanillaCalendar('#datepicker', {
             if(enableCalendarHighlight){
                 webviewApi.postMessage({"type": "noteExists", "date": date}).then(res => {
                     if(res){
-                        HTMLButtonElement.style["border"] = `1px solid ${calendarHighlightColor}`
-                        HTMLButtonElement.style["margin"] = "1px"
+                        HTMLButtonElement.classList.add("vanilla-calendar-day_noted");
                     }
                 })
             }

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -26,6 +26,7 @@ const timeFmt:any = parseInt(date_ele.getAttribute('timeFmt'),10)
 const theme:any = date_ele.getAttribute('theme')
 const enableWeekNum = date_ele.getAttribute('weekNum') === 'true'
 const days_with_notes_ele = document.getElementById('days_with_notes')
+const calendarHighlightColor = days_with_notes_ele.getAttribute('calendarHighlightColor')
 
 const calendar = new VanillaCalendar('#datepicker', {
     actions: {
@@ -43,7 +44,8 @@ const calendar = new VanillaCalendar('#datepicker', {
        },
        getDays(day, date, HTMLElement, HTMLButtonElement) {
             if(days_with_notes_ele.getAttribute(date)){
-                HTMLButtonElement.style["border"] = "1px solid rgb(112, 112, 255)"
+                HTMLButtonElement.style["border"] = `1px solid ${calendarHighlightColor}`
+                HTMLButtonElement.style["margin"] = "1px"
             }
        },
     },

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -25,6 +25,8 @@ const monday_first = date_ele.getAttribute('iso8601') === 'true'
 const timeFmt:any = parseInt(date_ele.getAttribute('timeFmt'),10)
 const theme:any = date_ele.getAttribute('theme')
 const enableWeekNum = date_ele.getAttribute('weekNum') === 'true'
+const days_with_notes_ele = document.getElementById('days_with_notes')
+
 const calendar = new VanillaCalendar('#datepicker', {
     actions: {
        clickDay(e, dates) {
@@ -38,6 +40,11 @@ const calendar = new VanillaCalendar('#datepicker', {
             console.log(`Vanilla Calendar: time: ${time}`)
             console.log(`Vanilla Calendar: hour: ${hours} minutes: ${minutes}`)
             console.log(`Vanilla Calendar: keeping: ${keeping}`)
+       },
+       getDays(day, date, HTMLElement, HTMLButtonElement) {
+            if(days_with_notes_ele.getAttribute(date)){
+                HTMLButtonElement.style["border"] = "1px solid rgb(112, 112, 255)"
+            }
        },
     },
     settings: {

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -3,6 +3,8 @@ import VanillaCalendar from '@uvarov.frontend/vanilla-calendar';
 //import '@uvarov.frontend/vanilla-calendar/build/themes/light.min.css';
 //import '@uvarov.frontend/vanilla-calendar/build/themes/dark.min.css';
 
+declare const webviewApi: any;
+
 function padding(v) {
     return ('0' + v).slice(-2)
 }
@@ -25,8 +27,8 @@ const monday_first = date_ele.getAttribute('iso8601') === 'true'
 const timeFmt:any = parseInt(date_ele.getAttribute('timeFmt'),10)
 const theme:any = date_ele.getAttribute('theme')
 const enableWeekNum = date_ele.getAttribute('weekNum') === 'true'
-const days_with_notes_ele = document.getElementById('days_with_notes')
-const calendarHighlightColor = days_with_notes_ele.getAttribute('calendarHighlightColor')
+const calendarHighlightColor = date_ele.getAttribute('calendarHighlightColor')
+const enableCalendarHighlight = date_ele.getAttribute('enableCalendarHighlight') === "true"
 
 const calendar = new VanillaCalendar('#datepicker', {
     actions: {
@@ -43,9 +45,13 @@ const calendar = new VanillaCalendar('#datepicker', {
             console.log(`Vanilla Calendar: keeping: ${keeping}`)
        },
        getDays(day, date, HTMLElement, HTMLButtonElement) {
-            if(days_with_notes_ele.getAttribute(date)){
-                HTMLButtonElement.style["border"] = `1px solid ${calendarHighlightColor}`
-                HTMLButtonElement.style["margin"] = "1px"
+            if(enableCalendarHighlight){
+                webviewApi.postMessage({"type": "noteExists", "date": date}).then(res => {
+                    if(res){
+                        HTMLButtonElement.style["border"] = `1px solid ${calendarHighlightColor}`
+                        HTMLButtonElement.style["margin"] = "1px"
+                    }
+                })
             }
        },
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import joplin from 'api';
 import { SettingItemType } from 'api/types';
+import { clearInterval } from 'timers';
 
 const defaultNoteName = 'Journal/{{year}}/{{monthName}}/{{year}}-{{month}}-{{day}}';
 const defaultMonthName = '01-Jan,02-Feb,03-Mar,04-Apr,05-May,06-Jun,07-Jul,08-Aug,09-Sep,10-Oct,11-Nov,12-Dec';
@@ -273,19 +274,37 @@ joplin.plugins.register({
 		}
 
 		let daysWithNotes = []
-		setTimeout(async () => { // Update cached list every 10 minutes
-			daysWithNotes = await getDatesWithNotes()
-		}, 5000);
-		setInterval(async () => { // Update cached list every 10 minutes
-			daysWithNotes = await getDatesWithNotes()
-		}, 60 * 10 * 1000);
+		let highlightInterval = undefined
+		async function updateCalendarInterval(){
+			if(await joplin.settings.value("HighlightCalendar")){
+				if(!highlightInterval){
+					// Run now to get initial data
+					setTimeout(async () => {
+						daysWithNotes = await getDatesWithNotes()
+					}, 2000);
+
+					let intervalMinutes = await joplin.settings.value("HighlightCalendarInterval") || 10;
+					highlightInterval = setInterval(async () => { // Update cached list every 10 minutes
+						daysWithNotes = await getDatesWithNotes()
+					}, 60 * 1000 * intervalMinutes);
+				}
+			} else if(highlightInterval) {
+				clearInterval(highlightInterval)
+				highlightInterval = undefined
+				daysWithNotes = []
+			}
+		}
+
 		async function getDateByDialog() {
 			const iso8601 = await joplin.settings.value('iso8601');
 			const timeFmt = await joplin.settings.value('TimeFmt') || 0;
 			const theme = await joplin.settings.value('Theme') || "light"
 			const enableWeekNum = await joplin.settings.value('WeekNum') || false
-
-			await dialogs.setHtml(dialog, `<form name="picker"><div id="datepicker" iso8601=${iso8601} timeFmt=${timeFmt} theme=${theme} weekNum=${enableWeekNum}></div><input id="j_date" name="date" type="hidden"><input id="j_time" name="time" type="hidden"><div <div id="days_with_notes" ${daysWithNotes.join("=true ") + "=true"}></div></form>`);
+			const calendarHighlightColor = await joplin.settings.value('HighlightCalendarColor')
+			updateCalendarInterval() // Check settings on calendar
+			const enableCalendarHighlight = await joplin.settings.value("HighlightCalendar")
+			let calendarHighlightHtml = `<div id="days_with_notes" calendarHighlightColor=${calendarHighlightColor} ${enableCalendarHighlight ? daysWithNotes.map(el=> el+"=true").join(" ") : ""}></div>`
+			await dialogs.setHtml(dialog, `<form name="picker"><div id="datepicker" iso8601=${iso8601} timeFmt=${timeFmt} theme=${theme} weekNum=${enableWeekNum}></div><input id="j_date" name="date" type="hidden"><input id="j_time" name="time" type="hidden">${calendarHighlightHtml}</form>`);
 			const ret = await dialogs.open(dialog);
 
 			if (ret.id == "ok") {
@@ -463,6 +482,33 @@ joplin.plugins.register({
 				label: 'Tag Names',
 				description: "Custom tag names, each value is separated by ','. eg",
 			},
+			'HighlightCalendar': {
+				value: false,
+				type: SettingItemType.Bool,
+				section: 'Journal',
+				public: true,
+				advanced: true,
+				label: 'Enable Calendar Highlights',
+				description: "Highlight days with notes on the calendar",
+			},
+			'HighlightCalendarInterval': {
+				value: 10,
+				type: SettingItemType.Int,
+				section: 'Journal',
+				public: true,
+				advanced: true,
+				label: 'Calendar Update Period',
+				description: "How often in minutes to update calendar highlights",
+			},
+			'HighlightCalendarColor': {
+				value: "#7070ff",
+				type: SettingItemType.String,
+				section: 'Journal',
+				public: true,
+				advanced: true,
+				label: 'Calendar Highlight Color',
+				description: "CSS color of calendar highlight",
+			},
 		});
 
 		await joplin.commands.register({
@@ -539,5 +585,7 @@ joplin.plugins.register({
 				await joplin.commands.execute('openTodayNote');
 			}, 2000);
 		}
+
+		updateCalendarInterval() // Check the calendar highlight settings
 	},
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,6 +232,7 @@ joplin.plugins.register({
 		await dialogs.addScript(dialog, "./vanilla-calendar.min.css");
 		await dialogs.addScript(dialog, "./light.min.css");
 		await dialogs.addScript(dialog, "./dark.min.css");
+		await dialogs.addScript(dialog, "vnilla-calendar-ext.css");
 		await dialogs.addScript(dialog, "./calendar.js");
 		await dialogs.setButtons(dialog, [
 			{ id: "ok", title: "OK" },
@@ -243,9 +244,8 @@ joplin.plugins.register({
 			const timeFmt = await joplin.settings.value('TimeFmt') || 0;
 			const theme = await joplin.settings.value('Theme') || "light"
 			const enableWeekNum = await joplin.settings.value('WeekNum') || false
-			const calendarHighlightColor = await joplin.settings.value('HighlightCalendarColor')
 			const enableCalendarHighlight = await joplin.settings.value("HighlightCalendar")
-			await dialogs.setHtml(dialog, `<form name="picker"><div id="datepicker" iso8601=${iso8601} timeFmt=${timeFmt} theme=${theme} weekNum=${enableWeekNum} calendarHighlightColor=${calendarHighlightColor} enableCalendarHighlight=${enableCalendarHighlight}></div><input id="j_date" name="date" type="hidden"><input id="j_time" name="time" type="hidden"></form>`);
+			await dialogs.setHtml(dialog, `<form name="picker"><div id="datepicker" iso8601=${iso8601} timeFmt=${timeFmt} theme=${theme} weekNum=${enableWeekNum} enableCalendarHighlight=${enableCalendarHighlight}></div><input id="j_date" name="date" type="hidden"><input id="j_time" name="time" type="hidden"></form>`);
 			joplin.views.panels.onMessage(dialog, async (msg) => {
 				if(msg.type == "noteExists"){
 					// Convert the date to local time
@@ -460,15 +460,6 @@ joplin.plugins.register({
 				advanced: true,
 				label: 'Enable Calendar Highlights',
 				description: "Highlight days with notes on the calendar",
-			},
-			'HighlightCalendarColor': {
-				value: "#7070ff",
-				type: SettingItemType.String,
-				section: 'Journal',
-				public: true,
-				advanced: true,
-				label: 'Calendar Highlight Color',
-				description: "CSS color of calendar highlight",
 			},
 		});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,16 +237,12 @@ joplin.plugins.register({
 			{ id: "cancel", title: "Cancel" },
 		]);
 
-		async function getDateByDialog() {
-			const iso8601 = await joplin.settings.value('iso8601');
-			const timeFmt = await joplin.settings.value('TimeFmt') || 0;
-			const theme = await joplin.settings.value('Theme') || "light"
-			const enableWeekNum = await joplin.settings.value('WeekNum') || false
-
+		async function getDatesWithNotes() {
 			// Iterate over year of dates
 			let now = new Date(new Date().getTime() - new Date().getTimezoneOffset()*60*1000)
 			let start = new Date(new Date().getTime() - new Date().getTimezoneOffset()*60*1000)
 			start.setDate(start.getDate() - 365)
+
 			let daysWithNotes = []
 			for (var d = start; d <= now; d.setDate(d.getDate() + 1)) {
 				// Get the name of a note for this day
@@ -273,6 +269,21 @@ joplin.plugins.register({
 					}
 				}
 			}
+			return daysWithNotes
+		}
+
+		let daysWithNotes = []
+		setTimeout(async () => { // Update cached list every 10 minutes
+			daysWithNotes = await getDatesWithNotes()
+		}, 5000);
+		setInterval(async () => { // Update cached list every 10 minutes
+			daysWithNotes = await getDatesWithNotes()
+		}, 60 * 10 * 1000);
+		async function getDateByDialog() {
+			const iso8601 = await joplin.settings.value('iso8601');
+			const timeFmt = await joplin.settings.value('TimeFmt') || 0;
+			const theme = await joplin.settings.value('Theme') || "light"
+			const enableWeekNum = await joplin.settings.value('WeekNum') || false
 
 			await dialogs.setHtml(dialog, `<form name="picker"><div id="datepicker" iso8601=${iso8601} timeFmt=${timeFmt} theme=${theme} weekNum=${enableWeekNum}></div><input id="j_date" name="date" type="hidden"><input id="j_time" name="time" type="hidden"><div <div id="days_with_notes" ${daysWithNotes.join("=true ") + "=true"}></div></form>`);
 			const ret = await dialogs.open(dialog);

--- a/src/vnilla-calendar-ext.css
+++ b/src/vnilla-calendar-ext.css
@@ -1,0 +1,9 @@
+.vanilla-calendar-day_noted::after {
+    content: '';
+    position: absolute;
+    bottom: 0px;
+    width: 6px;
+    height: 6px;
+    border-radius: 3px;
+    background-color: gray;
+}


### PR DESCRIPTION
This adds a border on calendar days that have notes, requested in #27. See the following image, in which I have notes for all days through August 26.

![image](https://github.com/user-attachments/assets/1c4069c8-4629-4517-909d-10a2a5111a57)

This works by setting an attribute on a form element, similar to how the settings are passed into the calendar script.

Currently, this implementation only will check for notes over the last year. This limitation is because querying for notes on days is slow, and this change adds ~3 seconds of latency when opening the calendar. I'm looking for any suggestions on improving this.