### PR TITLE
Add option to shift the start hour of the day

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,13 @@ joplin.plugins.register({
 			{ id: "cancel", title: "Cancel" },
 		]);
 
+		async function getDateWithOffset() {
+			const offset = await joplin.settings.value('DayStart')
+			let d = new Date(new Date().getTime() - 1000*60*60*offset);
+			console.log("Journal Date with Offset: ", d)
+			return d;
+		}
+
 		async function getDateByDialog() {
 			const iso8601 = await joplin.settings.value('iso8601');
 			const timeFmt = await joplin.settings.value('TimeFmt') || 0;
@@ -478,7 +485,7 @@ joplin.plugins.register({
 			name: "openTodayNote",
 			label: "Open Today's Note",
 			execute: async () => {
-				const d = new Date();
+				const d = await getDateWithOffset();
 				const note = await createNoteByDate(d);
 				await joplin.commands.execute("openNote", note.id);
 				await joplin.commands.execute('editor.focus');
@@ -502,7 +509,7 @@ joplin.plugins.register({
 			name: "linkTodayNote",
 			label: "Insert link to Today's Note",
 			execute: async () => {
-				const d = new Date();
+				const d = await getDateWithOffset();
 				const note = await createNoteByDate(d);
 				await joplin.commands.execute("insertText", `[${note.title}](:/${note.id})`);
 				await joplin.commands.execute('editor.focus');
@@ -526,7 +533,7 @@ joplin.plugins.register({
 			name: "linkTodayNoteWithLabel",
 			label: "Insert link to Today's Note with label 'Today'",
 			execute: async () => {
-				const d = new Date();
+				const d = await getDateWithOffset();
 				const note = await createNoteByDate(d);
 				await joplin.commands.execute("insertText", `[Today](:/${note.id})`);
 				await joplin.commands.execute('editor.focus');

--- a/src/index.ts
+++ b/src/index.ts
@@ -397,6 +397,17 @@ joplin.plugins.register({
 				},
 				description: "Select preferred format for time.",
 			},
+			'DayStart': {
+				value: 0,
+				type: SettingItemType.Int,
+				section: 'Journal',
+				minimum: -6,
+				maximum: 6,
+				public: true,
+				advanced: true,
+				label: 'Day start',
+				description: "Select how many hours before or after midnight your day should start.",
+			},
 			'Theme': {
 				value: "light",
 				type: SettingItemType.String,


### PR DESCRIPTION
Hey, I frequently create my daily note after midnight, which means I wasn't able to use the shortcut for opening today's note. I wanted an option to delay the start of the day and thought others might find it useful too. 

This change lets users decide whether they want to shift the hours of the day by up to 6 hours in both directions. For example: setting it to 5 means that creating a note at any point before 5am will actually create a note for the day before. On the other hand setting it to -5 would shift the hours in the other direction, creating a note for the next day starting from 7pm.

Let me know if there are any issues.