### PR TITLE
Add mobile support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import joplin from 'api';
-import { SettingItemType } from 'api/types';
+import { SettingItemType, ToolbarButtonLocation } from 'api/types';
 
 const defaultNoteName = 'Journal/{{year}}/{{monthName}}/{{year}}-{{month}}-{{day}}';
 const defaultMonthName = '01-Jan,02-Feb,03-Mar,04-Apr,05-May,06-Jun,07-Jul,08-Aug,09-Sep,10-Oct,11-Nov,12-Dec';
@@ -585,6 +585,7 @@ joplin.plugins.register({
 		await joplin.commands.register({
 			name: "linkTodayNote",
 			label: "Insert link to Today's Note",
+			iconName: "fas fa-calendar-times",
 			execute: async () => {
 				const d = new Date();
 				const note = await createNoteByDate(d);
@@ -607,6 +608,7 @@ joplin.plugins.register({
 		await joplin.commands.register({
 			name: "linkOtherDayNote",
 			label: "Insert link to Another day's Note",
+			iconName: "fas fa-calendar-alt",
 			execute: async () => {
 				let d = await getDateByDialog();
 				if (d !== null) {
@@ -657,5 +659,40 @@ joplin.plugins.register({
 				await joplin.commands.execute('openTodayNote');
 			}, 2000);
 		}
+
+		const isMobilePlatform = await isMobile();
+		if (isMobilePlatform) {
+			console.log({isMobilePlatform})
+			await joplin.views.toolbarButtons.create(
+				"openTodayNoteMobile",
+				"openTodayNote",
+				ToolbarButtonLocation.NoteToolbar
+		  	);
+			await joplin.views.toolbarButtons.create(
+				"openOtherdayNoteMobile",
+				"openOtherdayNote",
+				ToolbarButtonLocation.NoteToolbar
+		  	);
+			await joplin.views.toolbarButtons.create(
+				"linkTodayNoteMobile",
+				"linkTodayNote",
+				ToolbarButtonLocation.EditorToolbar
+		  	);
+			await joplin.views.toolbarButtons.create(
+				"linkOtherDayNoteMobile",
+				"linkOtherDayNote",
+				ToolbarButtonLocation.EditorToolbar
+		  	);
+		}
 	},
 });
+
+const isMobile = async () => {
+	try {
+		const version = await joplin.versionInfo() as any;
+		return version?.platform === 'mobile';
+	} catch(error) {
+		console.warn('Error checking whether the device is a mobile device. Assuming desktop.', error);
+		return false;
+	}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -544,6 +544,8 @@ joplin.plugins.register({
 			},
 		});
 
+		const isMobilePlatform = await isMobile();
+
 		await joplin.commands.register({
 			name: "openTodayNote",
 			label: "Open Today's Note",
@@ -552,7 +554,9 @@ joplin.plugins.register({
 				const note = await createNoteByDate(d);
 				await insertTemplate(note.id);
 				await joplin.commands.execute("openNote", note.id);
-				await joplin.commands.execute('editor.focus');
+				if (!isMobilePlatform) {
+					await joplin.commands.execute('editor.focus');
+				}
 			}
 		});
 
@@ -564,7 +568,9 @@ joplin.plugins.register({
 				const note = await createNoteByDate(d);
 				await insertTemplate(note.id);
 				await joplin.commands.execute("openNote", note.id);
-				await joplin.commands.execute('editor.focus');
+				if (!isMobilePlatform) {
+					await joplin.commands.execute('editor.focus');
+				}
 			}
 		});
 
@@ -577,7 +583,9 @@ joplin.plugins.register({
 					const note = await createNoteByDate(d);
 					await insertTemplate(note.id);
 					await joplin.commands.execute("openNote", note.id);
-					await joplin.commands.execute('editor.focus');
+					if (!isMobilePlatform) {
+						await joplin.commands.execute('editor.focus');
+					}
 				}
 			}
 		});
@@ -590,7 +598,6 @@ joplin.plugins.register({
 				const d = new Date();
 				const note = await createNoteByDate(d);
 				await joplin.commands.execute("insertText", `[${note.title}](:/${note.id})`);
-				await joplin.commands.execute('editor.focus');
 			}
 		});
 
@@ -602,7 +609,6 @@ joplin.plugins.register({
 				const d = await getDateWithOffset();
 				const note = await createNoteByDate(d);
 				await joplin.commands.execute("insertText", `[${note.title}](:/${note.id})`);
-				await joplin.commands.execute('editor.focus');
 			}
 		});
 
@@ -615,7 +621,6 @@ joplin.plugins.register({
 				if (d !== null) {
 					const note = await createNoteByDate(d);
 					await joplin.commands.execute("insertText", `[${note.title}](:/${note.id})`);
-					await joplin.commands.execute('editor.focus');
 				}
 			}
 		});
@@ -628,7 +633,6 @@ joplin.plugins.register({
 				const d = new Date();
 				const note = await createNoteByDate(d);
 				await joplin.commands.execute("insertText", `[Today](:/${note.id})`);
-				await joplin.commands.execute('editor.focus');
 			}
 		});
 
@@ -640,7 +644,6 @@ joplin.plugins.register({
 				const d = await getDateWithOffset();
 				const note = await createNoteByDate(d);
 				await joplin.commands.execute("insertText", `[Today](:/${note.id})`);
-				await joplin.commands.execute('editor.focus');
 			}
 		});
 
@@ -663,7 +666,6 @@ joplin.plugins.register({
 			}, 2000);
 		}
 
-		const isMobilePlatform = await isMobile();
 		if (isMobilePlatform) {
 			console.log({isMobilePlatform})
 			await joplin.settings.registerSettings({

--- a/src/index.ts
+++ b/src/index.ts
@@ -597,6 +597,7 @@ joplin.plugins.register({
 		await joplin.commands.register({
 			name: "linkOffsetTodayNote",
 			label: "Insert link to Today's Note (with Offset)",
+			iconName: "fas fa-calendar-times",
 			execute: async () => {
 				const d = await getDateWithOffset();
 				const note = await createNoteByDate(d);
@@ -622,6 +623,7 @@ joplin.plugins.register({
 		await joplin.commands.register({
 			name: "linkTodayNoteWithLabel",
 			label: "Insert link to Today's Note with label 'Today'",
+			iconName: "fas fa-calendar-minus",
 			execute: async () => {
 				const d = new Date();
 				const note = await createNoteByDate(d);
@@ -633,6 +635,7 @@ joplin.plugins.register({
 		await joplin.commands.register({
 			name: "linkOffsetTodayNoteWithLabel",
 			label: "Insert link to Today's Note with label 'Today' (with Offset) ",
+			iconName: "fas fa-calendar-minus",
 			execute: async () => {
 				const d = await getDateWithOffset();
 				const note = await createNoteByDate(d);
@@ -721,10 +724,25 @@ joplin.plugins.register({
 				"linkTodayNoteMobile",
 				"linkTodayNote",
 				ToolbarButtonLocation.EditorToolbar
-		  	);
+			);
+			await joplin.views.toolbarButtons.create(
+				"linkOffsetTodayNoteMobile",
+				"linkOffsetTodayNote",
+				ToolbarButtonLocation.EditorToolbar
+			);
 			await joplin.views.toolbarButtons.create(
 				"linkOtherDayNoteMobile",
 				"linkOtherDayNote",
+				ToolbarButtonLocation.EditorToolbar
+		  	);
+			await joplin.views.toolbarButtons.create(
+				"linkTodayNotewithLabelMobile",
+				"linkTodayNoteWithLabel",
+				ToolbarButtonLocation.EditorToolbar
+		  	);
+			await joplin.views.toolbarButtons.create(
+				"linkOffsetTodayNotewithLabelMobile",
+				"linkOffsetTodayNoteWithLabel",
 				ToolbarButtonLocation.EditorToolbar
 		  	);
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -663,16 +663,60 @@ joplin.plugins.register({
 		const isMobilePlatform = await isMobile();
 		if (isMobilePlatform) {
 			console.log({isMobilePlatform})
-			await joplin.views.toolbarButtons.create(
-				"openTodayNoteMobile",
-				"openTodayNote",
-				ToolbarButtonLocation.NoteToolbar
-		  	);
-			await joplin.views.toolbarButtons.create(
-				"openOtherdayNoteMobile",
-				"openOtherdayNote",
-				ToolbarButtonLocation.NoteToolbar
-		  	);
+			await joplin.settings.registerSettings({
+				'openTodayNoteSetting': {
+					value: false,
+					type: SettingItemType.Bool,
+					section: 'Journal',
+					public: true,
+					advanced: true,
+					label: 'Add Open Today\'s Note option to menu',
+					description: 'Adds the option to the three-dot menu on mobile. Needs restart to be effective',
+				},
+				'openOffsetTodayNoteSetting': {
+					value: false,
+					type: SettingItemType.Bool,
+					section: 'Journal',
+					public: true,
+					advanced: true,
+					label: 'Add Open Today\'s Note (with Offset) option to menu',
+					description: 'Adds the option to the three-dot menu on mobile. Needs restart to be effective',
+				},
+				'openOtherdayNoteSetting': {
+					value: false,
+					type: SettingItemType.Bool,
+					section: 'Journal',
+					public: true,
+					advanced: true,
+					label: 'Add Open Another day\'s Note option to menu',
+					description: 'Adds the option to the three-dot menu on mobile. Needs restart to be effective',
+				},
+			});
+			const openTodayNoteSetting = await joplin.settings.value('openTodayNoteSetting') || false;
+			const openOffsetTodayNoteSetting = await joplin.settings.value('openOffsetTodayNoteSetting') || false;
+			const openOtherdayNoteSetting = await joplin.settings.value('openOtherdayNoteSetting') || false;
+			if (openTodayNoteSetting) {
+				await joplin.views.toolbarButtons.create(
+					"openTodayNoteMobile",
+					"openTodayNote",
+					ToolbarButtonLocation.NoteToolbar
+				);
+			}
+			if (openOffsetTodayNoteSetting) {
+				await joplin.views.toolbarButtons.create(
+					"openOffsetTodayNoteMobile",
+					"openOffsetTodayNote",
+					ToolbarButtonLocation.NoteToolbar
+				);
+			}
+			if (openOtherdayNoteSetting) {
+				await joplin.views.toolbarButtons.create(
+					"openOtherdayNoteMobile",
+					"openOtherdayNote",
+					ToolbarButtonLocation.NoteToolbar
+				);
+			}
+
 			await joplin.views.toolbarButtons.create(
 				"linkTodayNoteMobile",
 				"linkTodayNote",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,5 +10,9 @@
 	"repository_url": "https://github.com/leenzhu/joplin-plugin-journal",
 	"keywords": [
 		"joplin-plugin"
+	],
+	"platforms": [
+		"desktop",
+		"mobile"
 	]
 }


### PR DESCRIPTION
This pull request enables mobile support.

Changes:
- updated manifest.json to reflect mobile as a platform
- added settings on mobile to add commands to *open* notes to the three-dot menu 
    - needs restart to be effective
    - three-dot menu can be viewed by opening any note
- added commands to *insert links* to toolbar
    - user can select which commands they want to have on their toolbar by editing the toolbar settings
- added icons for commands that can be added to the toolbar 
    - versions with offset vs without have the same icon since one user probably only uses one of those commands
- fixed `editor.focus` issues by only calling that command on desktop and removing the command on commands that link to notes (it wasn't necessary to call the command there, the editor already has focus in those cases)

How to test:
- installing the `.jpl` file onto any Android device in the advanced plugin settings
- using the [web client](https://app.joplincloud.com/)

Let me know if you have any questions or issues!