### PR TITLE
Insert template when linking note

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -588,6 +588,10 @@ joplin.plugins.register({
 			execute: async () => {
 				const d = new Date();
 				const note = await createNoteByDate(d);
+				const insertTemplateEveryTime = await joplin.settings.value('insertTemplateEveryTime');
+				if (!insertTemplateEveryTime) {
+					await insertTemplate(note.id);
+				}
 				await joplin.commands.execute("insertText", `[${note.title}](:/${note.id})`);
 				await joplin.commands.execute('editor.focus');
 			}
@@ -599,6 +603,10 @@ joplin.plugins.register({
 			execute: async () => {
 				const d = await getDateWithOffset();
 				const note = await createNoteByDate(d);
+				const insertTemplateEveryTime = await joplin.settings.value('insertTemplateEveryTime');
+				if (!insertTemplateEveryTime) {
+					await insertTemplate(note.id);
+				}
 				await joplin.commands.execute("insertText", `[${note.title}](:/${note.id})`);
 				await joplin.commands.execute('editor.focus');
 			}
@@ -611,6 +619,10 @@ joplin.plugins.register({
 				let d = await getDateByDialog();
 				if (d !== null) {
 					const note = await createNoteByDate(d);
+					const insertTemplateEveryTime = await joplin.settings.value('insertTemplateEveryTime');
+					if (!insertTemplateEveryTime) {
+						await insertTemplate(note.id);
+					}
 					await joplin.commands.execute("insertText", `[${note.title}](:/${note.id})`);
 					await joplin.commands.execute('editor.focus');
 				}
@@ -623,6 +635,10 @@ joplin.plugins.register({
 			execute: async () => {
 				const d = new Date();
 				const note = await createNoteByDate(d);
+				const insertTemplateEveryTime = await joplin.settings.value('insertTemplateEveryTime');
+				if (!insertTemplateEveryTime) {
+					await insertTemplate(note.id);
+				}
 				await joplin.commands.execute("insertText", `[Today](:/${note.id})`);
 				await joplin.commands.execute('editor.focus');
 			}
@@ -634,6 +650,10 @@ joplin.plugins.register({
 			execute: async () => {
 				const d = await getDateWithOffset();
 				const note = await createNoteByDate(d);
+				const insertTemplateEveryTime = await joplin.settings.value('insertTemplateEveryTime');
+				if (!insertTemplateEveryTime) {
+					await insertTemplate(note.id);
+				}
 				await joplin.commands.execute("insertText", `[Today](:/${note.id})`);
 				await joplin.commands.execute('editor.focus');
 			}


### PR DESCRIPTION
Hey, I've noticed that when I create a note that doesn't exist yet by linking to it, the template doesn't get inserted. 
I remember that I implemented it this way because of the feature to insert the template every time, which wouldn't make sense to do when just linking to a note instead of opening it. But I just added an if-statement for that case, so the template only gets inserted by linking if the option to insert it every time is turned off.

Please tell me if you have any issues with my implementation or questions :)