### PR TITLE
Add memories from previous journal entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 1. **FEAT** Add an `Insert memories` command that links journal entries from the same date in previous years.
 2. **FEAT** Add the content-template-only `{{memories}}` variable.
-3. **DOCS** Document memories, custom title suffix handling, and template usage.
+3. **FEAT** Add `Insert memories` to the mobile editor toolbar.
+4. **DOCS** Document memories, custom title suffix handling, template usage, and the mobile toolbar action.
 
 ## v2.7.0 (2026-05-29)
 1. **FEAT** Support matching journal notes with custom title suffixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+1. **FEAT** Add an `Insert memories` command that links journal entries from the same date in previous years.
+2. **FEAT** Add the content-template-only `{{memories}}` variable.
+3. **DOCS** Document memories, custom title suffix handling, and template usage.
+
 ## v2.7.0 (2026-05-29)
 1. **FEAT** Support matching journal notes with custom title suffixes.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ On mobile, Journal can add selected "open note" actions to the note toolbar thro
 - `Add Open Today's Note (with Offset) option to menu`
 - `Add Open Another day's Note option to menu`
 
-Link insertion actions are also added to the mobile editor toolbar.
+Link insertion actions and `Insert memories` are also added to the mobile editor toolbar. Open a journal note in edit mode and tap the history button to insert links to entries from previous years at the cursor.
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Joplin Plugin - Journal
 
-Create or open a note for today, or for another date selected from a date picker. The plugin can build a notebook hierarchy from a template, insert template content into journal notes, and add links between notes.
+Create or open a note for today, or for another date selected from a date picker. The plugin can build a notebook hierarchy from a template, insert template content into journal notes, add links between notes, and revisit journal entries from the same date in previous years.
 
 ![joplin-plugin-journal-screen-shot](https://raw.githubusercontent.com/leenzhu/joplin-plugin-journal/master/joplin-plugin-journal.png)
 ![joplin-plugin-journal-screen-shot](https://raw.githubusercontent.com/leenzhu/joplin-plugin-journal/master/joplin-plugin-journal-setting.png)
@@ -15,6 +15,8 @@ Create or open a note for today, or for another date selected from a date picker
 - Insert links labeled `Today`.
 - Insert note template content automatically or manually.
 - Expand template variables in both note names and inserted note content.
+- Insert links to journal entries from the same month and day in previous years ("memories").
+- Add memories automatically to note content templates with `{{memories}}`.
 - Match notes by exact generated title, or optionally by generated-title prefix to allow custom title suffixes.
 - Add tags automatically to newly created journal notes.
 - Highlight dates with existing notes in the date picker.
@@ -39,8 +41,23 @@ Available actions:
 - `Insert link to Today's Note with Label`
 - `Insert link to Today's Note with Label (with Offset)`
 - `Insert Default Template`
+- `Insert memories`
 
 If the target note does not exist yet, Journal creates it automatically.
+
+### Memories
+
+`Insert memories` checks whether the currently selected note matches `Note Name Template`. If it does, Journal determines its date from the generated notebook path and note title, finds existing journal entries for the same month and day in previous years, and inserts one Markdown link per year at the cursor. Links are ordered from newest to oldest and each link is placed on its own line.
+
+For example, with `Timeline/{{year}}/{{year}}{{month}}{{day}}`, running the command in `Timeline/2026/20260906` can insert:
+
+```markdown
+[20250906 Plum](:/NOTE_ID)
+[20230906 Banana](:/NOTE_ID)
+[20210906 Cherry](:/NOTE_ID)
+```
+
+When `Allow custom title suffix` is enabled, suffixes such as ` Plum` are ignored when determining the journal date, but the complete note title is used as the link label. If an exact title and suffixed matches exist for the same year, the exact title is preferred; otherwise the earliest-created suffixed match is used. The command never creates missing notes.
 
 ### Keyboard Shortcuts
 
@@ -70,6 +87,7 @@ You can customize shortcuts via `Tools` -> `Options` -> `Keyboard Shortcuts`. Se
 - Template variables are expanded in the inserted content.
 - If `Insert template every time note is opened` is disabled, the template is inserted only when the note body is empty.
 - `Insert Default Template` manually inserts the configured template into the current note.
+- The content-only variable `{{memories}}` inserts the same list of previous-year links when the template is applied. If there are no matching entries, it expands to an empty string.
 
 ### Mobile
 
@@ -129,7 +147,7 @@ Journal templates can be used in two places:
 - `Note Name Template`: controls the generated journal note path and title.
 - `Note Template ID`: points to a note whose body will be inserted as the journal note content template.
 
-Template variables are expanded in both the note name template and the inserted note content template.
+The date and time variables below are expanded in both the note name template and the inserted note content template. `{{memories}}` is available only in the inserted note content template.
 
 ### Supported Variables
 
@@ -152,13 +170,14 @@ Template variables are expanded in both the note name template and the inserted 
 | `{{weekday}}` | Weekday number. The exact format depends on `Weekday Style`. | `05` or `5` |
 | `{{weekdayName}}` | Weekday label from the `Weekday Name` setting. | `Thu` |
 | `{{weekNum}}` | Week number based on the plugin's current week-number calculation. | `22` |
+| `{{memories}}` | Links to journal entries from the same month and day in previous years, one per line. Available only in the note content template. | `[20250906 Plum](:/NOTE_ID)` |
 
 ### Formatting Notes
 
 - A `/` in `Note Name Template` creates a notebook hierarchy.
 - `Month Name`, `Weekday Name`, and `Quarter Name` are user-configurable lists, so the rendered text depends on your settings.
 - `Month Style`, `Day Style`, `Weekday Style`, and `WeekNum Style` control whether numeric values are zero-padded or plain numbers.
-- Variables are expanded in both note names and inserted note content.
+- Date and time variables are expanded in both note names and inserted note content. `{{memories}}` works only in the note referenced by `Note Template ID` and cannot be used in `Note Name Template`.
 
 ### Default Note Name Template
 
@@ -183,6 +202,10 @@ Example inserted note content template:
 
 Created at {{time}}
 Week {{weekNum}}, {{weekdayName}}
+
+## On this day
+
+{{memories}}
 ```
 
 ## Known issues

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,7 +97,7 @@
 - `Add Open Today's Note (with Offset) option to menu`
 - `Add Open Another day's Note option to menu`
 
-插入链接相关操作也会添加到移动端编辑器工具栏。
+插入链接相关操作和 `Insert memories` 也会添加到移动端编辑器工具栏。在编辑模式下打开日志笔记，然后点击历史记录按钮，即可在光标位置插入往年日志链接。
 
 ## 设置项说明
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # Joplin Plugin - Journal
 
-为今天创建或打开一篇日志笔记，或者通过日期选择器打开任意日期的日志。插件支持通过模板生成笔记本层级、向日志笔记插入模板内容，以及在笔记之间插入日志链接。
+为今天创建或打开一篇日志笔记，或者通过日期选择器打开任意日期的日志。插件支持通过模板生成笔记本层级、向日志笔记插入模板内容、在笔记之间插入日志链接，以及回顾往年同一天的日志。
 
 ![joplin-plugin-journal-screen-shot](https://raw.githubusercontent.com/leenzhu/joplin-plugin-journal/master/joplin-plugin-journal.png)
 ![joplin-plugin-journal-screen-shot](https://raw.githubusercontent.com/leenzhu/joplin-plugin-journal/master/joplin-plugin-journal-setting.png)
@@ -15,6 +15,8 @@
 - 插入显示为 `Today` 的日志链接。
 - 自动或手动插入模板内容。
 - 在笔记标题模板和笔记内容模板中展开模板变量。
+- 插入往年同月同日的日志链接（“Memories”）。
+- 使用 `{{memories}}` 自动把往年回忆加入内容模板。
 - 通过精确匹配标题，或可选地通过标题前缀匹配来支持自定义标题后缀。
 - 自动为新建日志添加标签。
 - 在日期选择器中高亮已有日志的日期。
@@ -39,8 +41,23 @@
 - `Insert link to Today's Note with Label`
 - `Insert link to Today's Note with Label (with Offset)`
 - `Insert Default Template`
+- `Insert memories`
 
 如果目标笔记不存在，Journal 会自动创建。
+
+### Memories（往年回忆）
+
+`Insert memories` 会先检查当前笔记是否符合 `Note Name Template`，再从笔记本路径和标题中确定日期。随后，Journal 会查找往年同月同日已有的日志，并在光标位置按年份从新到旧插入链接，每个年份一行。此命令不会创建缺失的笔记。
+
+例如，使用 `Timeline/{{year}}/{{year}}{{month}}{{day}}` 时，在 `Timeline/2026/20260906` 中运行命令可以插入：
+
+```markdown
+[20250906 Plum](:/NOTE_ID)
+[20230906 Banana](:/NOTE_ID)
+[20210906 Cherry](:/NOTE_ID)
+```
+
+启用 `Allow custom title suffix` 后，确定日期时会忽略 ` Plum` 之类的自定义后缀，但链接文字仍使用完整标题。同一年存在精确标题和后缀匹配时优先选择精确标题；否则选择最早创建的后缀匹配。
 
 ### 快捷键
 
@@ -70,6 +87,7 @@
 - 插入模板内容时会展开模板变量。
 - 如果 `Insert template every time note is opened` 未启用，则只有在目标笔记正文为空时才插入模板。
 - `Insert Default Template` 会把当前配置的模板内容手动插入到当前笔记中。
+- 仅用于内容模板的变量 `{{memories}}` 会在应用模板时插入相同的往年链接列表；没有匹配记录时会替换为空文本。
 
 ### 移动端
 
@@ -129,7 +147,7 @@ Journal 的模板可用于两个位置：
 - `Note Name Template`：控制生成的日志笔记路径和标题。
 - `Note Template ID`：指向一个笔记，该笔记正文会作为日志内容模板插入。
 
-模板变量会同时在笔记标题模板和插入的笔记内容模板中展开。
+下面的日期和时间变量会同时在笔记标题模板和插入的笔记内容模板中展开。`{{memories}}` 仅适用于插入的笔记内容模板。
 
 ### 支持的变量
 
@@ -152,13 +170,14 @@ Journal 的模板可用于两个位置：
 | `{{weekday}}` | 星期数字，具体格式取决于 `Weekday Style`。 | `05` 或 `5` |
 | `{{weekdayName}}` | 来自 `Weekday Name` 设置的星期标签。 | `Thu` |
 | `{{weekNum}}` | 按插件当前周数算法计算的周序号。 | `22` |
+| `{{memories}}` | 往年同月同日的日志链接，每行一条。仅可用于笔记内容模板。 | `[20250906 Plum](:/NOTE_ID)` |
 
 ### 格式说明
 
 - `Note Name Template` 中的 `/` 会创建笔记本层级。
 - `Month Name`、`Weekday Name` 和 `Quarter Name` 都是可配置列表，因此最终渲染结果取决于你的设置。
 - `Month Style`、`Day Style`、`Weekday Style` 和 `WeekNum Style` 用于控制数字是零填充还是普通数字。
-- 模板变量会同时在笔记标题和插入的模板内容中展开。
+- 日期和时间变量会同时在笔记标题和插入的模板内容中展开。`{{memories}}` 只能用于 `Note Template ID` 指向的笔记，不能用于 `Note Name Template`。
 
 ### 默认笔记标题模板
 
@@ -183,6 +202,10 @@ Journal/{{year}}/{{monthName}}/{{date}}
 
 Created at {{time}}
 Week {{weekNum}}, {{weekdayName}}
+
+## On this day
+
+{{memories}}
 ```
 
 ## 已知问题

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "joplin-plugin-journal",
   "version": "2.7.0",
+  "description": "Create daily Joplin journal notes, use content templates, and revisit entries from the same date in previous years.",
   "scripts": {
     "dist": "webpack --env joplin-plugin-config=buildMain && webpack --env joplin-plugin-config=buildExtraScripts && webpack --env joplin-plugin-config=createArchive",
     "prepare": "npm run dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1070,6 +1070,11 @@ joplin.plugins.register({
 				"linkOffsetTodayNoteWithLabel",
 				ToolbarButtonLocation.EditorToolbar
 		  	);
+			await joplin.views.toolbarButtons.create(
+				"insertMemoriesMobile",
+				"insertMemories",
+				ToolbarButtonLocation.EditorToolbar
+			);
 		}
 	},
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,18 +24,10 @@ function padding(s) {
 }
 
 function tplEngin(tpl, data) {
-	const re = /{{([^}]+)?}}/
-	let match
-	while (match = re.exec(tpl)) {
-		let v = data[match[1]];
-		if (typeof (v) === "string") {
-			v.replace(/{/g, "<");
-			v.replace(/}/g, ">"); // trim marker, prevent deadloop if 'v' contains '{{...}}'
-		}
-		tpl = tpl.replace(match[0], v ? v : `errkey_${match[1]}`);
-	}
-
-	return tpl;
+	return tpl.replace(/{{([^}]+)?}}/g, (_match, key) => {
+		const value = data[key];
+		return value !== undefined && value !== null ? String(value) : `errkey_${key}`;
+	});
 }
 
 async function makeTemplateData(d) {
@@ -301,6 +293,9 @@ async function makeTemplateBody(d) {
 
 	const templateBody = (await joplin.data.get(["notes", templateId], { fields: ["body"] }))["body"];
 	const data = await makeTemplateData(d);
+	if (templateBody.includes('{{memories}}')) {
+		data['memories'] = await memoriesMarkdownForDate(d);
+	}
 	return tplEngin(templateBody, data);
 }
 
@@ -365,6 +360,188 @@ async function linkNote(d, withLable= false) {
 	}
 	await joplin.commands.execute("insertText", `[${withLable ? "Today" : note.title}](:/${note.id})`);
 	return note;
+}
+
+function escapeRegExp(value: string) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function templatePathMatcher(template: string, allowTitleSuffix: boolean, monthNames: string[]) {
+	const values: string[] = [];
+	const patterns = {
+		year: '\\d{4}',
+		date: '\\d{4}-\\d{2}-\\d{2}',
+		datetime: '\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}',
+		month: '\\d{1,2}',
+		monthName: monthNames.map(escapeRegExp).join('|'),
+		day: '\\d{1,2}',
+	};
+	const parts = template.split('/');
+	const pattern = parts.map((part, partIndex) => {
+		let cursor = 0;
+		let result = '';
+		const placeholder = /{{([^}]+)}}/g;
+		let match: RegExpExecArray;
+		while ((match = placeholder.exec(part)) !== null) {
+			result += escapeRegExp(part.slice(cursor, match.index));
+			const key = match[1];
+			const capturePattern = patterns[key] || '[^/]+?';
+			result += `(${capturePattern})`;
+			values.push(key);
+			cursor = match.index + match[0].length;
+		}
+		result += escapeRegExp(part.slice(cursor));
+		if (allowTitleSuffix && partIndex === parts.length - 1) result += '.*';
+		return result;
+	}).join('/');
+
+	return { regex: new RegExp(`^${pattern}$`), values };
+}
+
+function dateFromTemplatePath(path: string, matcher, monthNames: string[]) {
+	const match = matcher.regex.exec(path);
+	if (!match) return null;
+
+	const data = {};
+	matcher.values.forEach((key, index) => {
+		if (data[key] === undefined) data[key] = match[index + 1];
+	});
+	let year: number;
+	let month: number;
+	let day: number;
+	const completeDate = data['date'] || data['datetime'];
+	if (completeDate) {
+		const dateParts = completeDate.slice(0, 10).split('-').map(Number);
+		[year, month, day] = dateParts;
+	} else {
+		year = Number(data['year']);
+		month = data['monthName'] ? monthNames.indexOf(data['monthName']) + 1 : Number(data['month']);
+		day = Number(data['day']);
+	}
+	if (!year || !month || !day) return null;
+	const date = new Date(year, month - 1, day);
+	if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) return null;
+	return date;
+}
+
+async function getAll(resource: string, fields: string[]) {
+	const items = [];
+	let page = 1;
+	let response;
+	do {
+		response = await joplin.data.get([resource], { fields, page, limit: 100 });
+		items.push(...response.items);
+		page++;
+	} while (response.has_more);
+	return items;
+}
+
+async function getAllFolders() {
+	const response = await joplin.data.get(['folders'], { fields: ['id', 'parent_id', 'title', 'deleted_time'] });
+	const roots = Array.isArray(response) ? response : response.items;
+	const folders = [];
+	const visit = (folder) => {
+		folders.push(folder);
+		for (const child of folder.children || []) visit(child);
+	};
+	for (const root of roots || []) visit(root);
+	return folders;
+}
+
+async function showMemoriesMessage(message: string, type = 'info') {
+	await (joplin.views.dialogs as any).showToast({ message, duration: 5000, timestamp: Date.now(), type });
+}
+
+async function memoriesMarkdownForDate(selectedDate: Date) {
+	const template = await joplin.settings.value('NoteTemplate') || defaultNoteName;
+	const allowTitleSuffix = await joplin.settings.value('AllowCustomTitleSuffix') || false;
+	const configuredMonthNames = await joplin.settings.value('MonthName') || defaultMonthName;
+	let monthNames = configuredMonthNames.split(',');
+	if (monthNames.length !== 12) monthNames = defaultMonthName.split(',');
+	const matcher = templatePathMatcher(template, allowTitleSuffix, monthNames);
+	const folders = await getAllFolders();
+	const folderById = new Map(folders.filter(folder => !folder.deleted_time).map(folder => [folder.id, folder]));
+	const folderPath = (folderId: string) => {
+		const titles = [];
+		const visited = new Set();
+		while (folderId && folderById.has(folderId) && !visited.has(folderId)) {
+			visited.add(folderId);
+			const folder: any = folderById.get(folderId);
+			titles.unshift(folder.title);
+			folderId = folder.parent_id;
+		}
+		return titles.join('/');
+	};
+
+	const notes = await getAll('notes', ['id', 'parent_id', 'title', 'deleted_time', 'user_created_time']);
+	const candidatesByYear = new Map();
+	for (const note of notes) {
+		if (note.deleted_time !== 0) continue;
+		const path = [folderPath(note.parent_id), note.title].filter(Boolean).join('/');
+		const date = dateFromTemplatePath(path, matcher, monthNames);
+		if (!date || date.getFullYear() >= selectedDate.getFullYear() ||
+			date.getMonth() !== selectedDate.getMonth() || date.getDate() !== selectedDate.getDate()) continue;
+		const expectedPath = await makeNoteName(date);
+		if (path !== expectedPath && !(allowTitleSuffix && path.startsWith(expectedPath))) continue;
+		const year = date.getFullYear();
+		const candidate = { note, year, exact: path === expectedPath };
+		const previous = candidatesByYear.get(year);
+		if (!previous || (candidate.exact && !previous.exact) ||
+			(candidate.exact === previous.exact && note.user_created_time < previous.note.user_created_time)) {
+			candidatesByYear.set(year, candidate);
+		}
+	}
+
+	const memories = Array.from(candidatesByYear.values());
+	memories.sort((a, b) => b.year - a.year || a.note.title.localeCompare(b.note.title));
+	if (!memories.length) return '';
+	return memories.map(({ note }) => {
+		const label = note.title.replace(/([\\\[\]])/g, '\\$1');
+		return `[${label}](:/${note.id})`;
+	}).join('\n') + '\n';
+}
+
+async function insertMemories() {
+	const selectedNote = await joplin.workspace.selectedNote();
+	if (!selectedNote) {
+		await showMemoriesMessage('Journal: No note is selected.');
+		return;
+	}
+
+	const template = await joplin.settings.value('NoteTemplate') || defaultNoteName;
+	const allowTitleSuffix = await joplin.settings.value('AllowCustomTitleSuffix') || false;
+	const configuredMonthNames = await joplin.settings.value('MonthName') || defaultMonthName;
+	let monthNames = configuredMonthNames.split(',');
+	if (monthNames.length !== 12) monthNames = defaultMonthName.split(',');
+	const matcher = templatePathMatcher(template, allowTitleSuffix, monthNames);
+	const folders = await getAllFolders();
+	const folderById = new Map(folders.filter(folder => !folder.deleted_time).map(folder => [folder.id, folder]));
+	const folderPath = (folderId: string) => {
+		const titles = [];
+		const visited = new Set();
+		while (folderId && folderById.has(folderId) && !visited.has(folderId)) {
+			visited.add(folderId);
+			const folder: any = folderById.get(folderId);
+			titles.unshift(folder.title);
+			folderId = folder.parent_id;
+		}
+		return titles.join('/');
+	};
+	const notePath = [folderPath(selectedNote.parent_id), selectedNote.title].filter(Boolean).join('/');
+	const selectedDate = dateFromTemplatePath(notePath, matcher, monthNames);
+	const expectedSelectedPath = selectedDate ? await makeNoteName(selectedDate) : '';
+	if (!selectedDate || (expectedSelectedPath !== notePath &&
+		!(allowTitleSuffix && notePath.startsWith(expectedSelectedPath)))) {
+		await showMemoriesMessage('Journal: The selected note is not a journal entry.');
+		return;
+	}
+
+	const markdown = await memoriesMarkdownForDate(selectedDate);
+	if (!markdown) {
+		await showMemoriesMessage('Journal: No memories found for this date.');
+		return;
+	}
+	await joplin.commands.execute('insertText', markdown);
 }
 
 joplin.plugins.register({
@@ -541,7 +718,7 @@ joplin.plugins.register({
 				public: true,
 				advanced: true,
 				label: 'Note Template ID',
-				description: "ID of the note that will be used as a template on creation of the note."
+				description: "ID of the note that will be used as a template on creation of the note. Use {{memories}} to insert links to journal entries from previous years."
 			},
 			'AllowCustomTitleSuffix': {
 				value: false,
@@ -772,6 +949,13 @@ joplin.plugins.register({
 			}
 		});
 
+		await joplin.commands.register({
+			name: "insertMemories",
+			label: "Insert memories",
+			iconName: "fas fa-history",
+			execute: insertMemories,
+		});
+
 		if (!isMobilePlatform) {
 			await joplin.views.toolbarButtons.create(
 				'journal_open_today_node',
@@ -788,6 +972,7 @@ joplin.plugins.register({
 
 			{ label: "Insert link to Today's Note with Label", commandName: "linkTodayNoteWithLabel", accelerator: "CmdOrCtrl+Alt+I" },
 			{ label: "Insert Default Template", commandName: "insertDefaultTemplate" },
+			{ label: "Insert memories", commandName: "insertMemories" },
 
 			{ label: "Open Today's Note (with Offset)", commandName: "openOffsetTodayNote", accelerator: "CmdOrCtrl+Shift+Alt+D" },
 			{ label: "Insert link to Today's Note (with Offset)", commandName: "linkOffsetTodayNote", accelerator: "CmdOrCtrl+Shift+Alt+L" },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,7 @@
 	"app_min_version": "2.7",
 	"version": "2.7.0",
 	"name": "Journal",
-	"description": "A simple journal. Create or open a note for today, or any selected date.",
+	"description": "Create daily journal notes, use content templates, and revisit entries from the same date in previous years.",
 	"author": "Leen Zhu",
 	"homepage_url": "https://github.com/leenzhu/joplin-plugin-journal",
 	"repository_url": "https://github.com/leenzhu/joplin-plugin-journal",


### PR DESCRIPTION
## Summary

Adds an "Insert memories" command that inserts links to journal entries
from the same month and day in previous years.

Also adds the `{{memories}}` variable for note content templates.

## Behavior

- Detects the journal date from the configured Note Name Template
- Supports custom title suffixes
- Inserts one link per previous year, ordered newest first
- Prefers exact title matches over suffixed matches
- Does not create missing journal entries
- `{{memories}}` is available only in note content templates

## Documentation

- Updated English and Chinese READMEs
- Updated plugin and package descriptions
- Added an Unreleased changelog entry

## Verification

- `npm run dist`
- `git diff --check`